### PR TITLE
Feat/viewCardBenefits: 로그인한 고객의 카드 혜택 조회 기능 추가

### DIFF
--- a/src/main/java/com/quostomize/quostomize_be/api/cardBenefit/controller/CardBenefitController.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/cardBenefit/controller/CardBenefitController.java
@@ -1,0 +1,31 @@
+package com.quostomize.quostomize_be.api.cardBenefit.controller;
+
+import com.quostomize.quostomize_be.api.cardBenefit.dto.CardBenefitResponse;
+import com.quostomize.quostomize_be.domain.customizer.cardBenefit.service.CardBenefitService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/benefit-change")
+@RequiredArgsConstructor
+public class CardBenefitController {
+    private final CardBenefitService cardBenefitService;
+
+    @GetMapping("/benefit-status")
+    @Operation(summary = "카드 혜택 내역 조회", description = "로그인한 고객의 카드 혜택 내역 조회 결과를 제공합니다.")
+    public ResponseEntity<List<CardBenefitResponse>> getCardBenefitStatus() {
+        List<CardBenefitResponse> benefits = cardBenefitService.findAll();
+        return ResponseEntity.ok(benefits);
+    }
+
+    // TODO: 혜택 변경 적용하기
+    
+    // TODO: 혜택 변경 예약하기 -> 테이블 분리여부 결정 필요
+
+}

--- a/src/main/java/com/quostomize/quostomize_be/api/cardBenefit/dto/CardBenefitResponse.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/cardBenefit/dto/CardBenefitResponse.java
@@ -1,0 +1,27 @@
+package com.quostomize.quostomize_be.api.cardBenefit.dto;
+import com.quostomize.quostomize_be.domain.customizer.cardBenefit.entity.CardBenefit;
+import java.time.LocalDateTime;
+
+public record CardBenefitResponse(
+        Long benefitId,
+        Integer benefitRate,
+        Boolean isActive,
+        Long cardId,
+        Long upperCategoryId,
+        Long lowerCategoryId,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public static CardBenefitResponse from(CardBenefit cardBenefit) {
+        return new CardBenefitResponse(
+                cardBenefit.getBenefitId(),
+                cardBenefit.getBenefitRate(),
+                cardBenefit.getIsActive(),
+                cardBenefit.getCard().getCardId(),
+                cardBenefit.getUpperCategory().getBenefitCommonId(),
+                cardBenefit.getLowerCategory().getBenefitCommonId(),
+                cardBenefit.getCreatedAt(),
+                cardBenefit.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/quostomize/quostomize_be/domain/customizer/cardBenefit/entity/CardBenefit.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/customizer/cardBenefit/entity/CardBenefit.java
@@ -1,6 +1,7 @@
-package com.quostomize.quostomize_be.domain.customizer.benefit.entity;
+package com.quostomize.quostomize_be.domain.customizer.cardBenefit.entity;
 
 import com.quostomize.quostomize_be.common.entity.BaseTimeEntity;
+import com.quostomize.quostomize_be.domain.customizer.benefit.entity.BenefitCommonCode;
 import com.quostomize.quostomize_be.domain.customizer.card.entity.Card;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/quostomize/quostomize_be/domain/customizer/cardBenefit/repository/CardBenefitRepository.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/customizer/cardBenefit/repository/CardBenefitRepository.java
@@ -1,0 +1,12 @@
+package com.quostomize.quostomize_be.domain.customizer.cardBenefit.repository;
+
+import com.quostomize.quostomize_be.domain.customizer.cardBenefit.entity.CardBenefit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+public interface CardBenefitRepository extends JpaRepository<CardBenefit, Long> {
+    Set<CardBenefit> findCardBenefitsByCardCardId(Long cardId);
+}

--- a/src/main/java/com/quostomize/quostomize_be/domain/customizer/cardBenefit/service/CardBenefitService.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/customizer/cardBenefit/service/CardBenefitService.java
@@ -1,0 +1,28 @@
+package com.quostomize.quostomize_be.domain.customizer.cardBenefit.service;
+
+import com.quostomize.quostomize_be.api.cardBenefit.dto.CardBenefitResponse;
+import com.quostomize.quostomize_be.domain.customizer.cardBenefit.entity.CardBenefit;
+import com.quostomize.quostomize_be.domain.customizer.cardBenefit.repository.CardBenefitRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class CardBenefitService {
+    private final CardBenefitRepository cardBenefitRepository;
+
+    public CardBenefitService(CardBenefitRepository cardBenefitRepository) {
+        this.cardBenefitRepository = cardBenefitRepository;
+    }
+
+    public List<CardBenefitResponse> findAll() {
+        // TODO: 하드코딩된 customer 정보 변경 필요
+        Long cardId = 1L;
+        Set<CardBenefit> cardBenefits = cardBenefitRepository.findCardBenefitsByCardCardId(cardId);
+        return cardBenefits.stream().map(CardBenefitResponse::from).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
- [x] 로그인한 고객의 카드에 적용된 모든 혜택을 조회합니다.
- [ ] card_benefit의 is_active가 0인 혜택내역은 조회되지 않습니다.
- [ ] Spring Security 반영한 이후 하드코딩한 고객id를 수정합니다.