### PR TITLE
Refactor: 멱등성 실패 로직 추가

### DIFF
--- a/src/main/java/com/quostomize/quostomize_be/common/idempotency/IdempotencyRedisRepository.java
+++ b/src/main/java/com/quostomize/quostomize_be/common/idempotency/IdempotencyRedisRepository.java
@@ -77,4 +77,32 @@ public class IdempotencyRedisRepository {
                 TimeUnit.MINUTES
         );
     }
+
+    public void saveFailedStatus(String idempotencyKey) {
+        String key = KEY_PREFIX + idempotencyKey;
+
+        IdempotencyResponse failedResponse = IdempotencyResponse.builder()
+                .processStatus(ProcessStatus.FAILED)
+                .build();
+
+        redisTemplate.opsForValue().set(
+                key,
+                failedResponse,
+                RESPONSE_EXPIRATION,
+                TimeUnit.MINUTES
+        );
+    }
+
+
+    public boolean canRetry(String idempotencyKey) {
+        String key = KEY_PREFIX + idempotencyKey;
+        IdempotencyResponse response = (IdempotencyResponse) redisTemplate.opsForValue().get(key);
+        log.info("[실패 상태]");
+        if (response == null) {
+            return false;
+        }
+
+        return response.isFailed();
+    }
+
 }

--- a/src/main/java/com/quostomize/quostomize_be/common/idempotency/IdempotencyResponse.java
+++ b/src/main/java/com/quostomize/quostomize_be/common/idempotency/IdempotencyResponse.java
@@ -23,4 +23,6 @@ public class IdempotencyResponse implements Serializable {
     public boolean isSucceed() {
         return this.processStatus == ProcessStatus.SUCCESS;
     }
+
+    public boolean isFailed() {return this.processStatus == ProcessStatus.FAILED;}
 }

--- a/src/main/java/com/quostomize/quostomize_be/common/idempotency/ProcessStatus.java
+++ b/src/main/java/com/quostomize/quostomize_be/common/idempotency/ProcessStatus.java
@@ -7,7 +7,8 @@ public enum ProcessStatus {
 
 
     PROCESSING("현재 해당 요청 처리 중"),
-    SUCCESS("요청 완료")
+    SUCCESS("요청 완료"),
+    FAILED("요청 실패")
 
     ;
 


### PR DESCRIPTION
- 멱등성 상태애서 요청이 실패하면 바로 다음 요청이 불가능했음
- 이 로직을 바로 다음 요청이 올바른 요청일때 정상 동작하도록 수정함