### PR TITLE
어드민: 로그인/로그아웃 log 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos
 
 docker-compose.yml
+
+# 로그 파일 무시하기
+logs/
+*.log

--- a/src/main/java/com/quostomize/quostomize_be/api/admin/controller/LogController.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/admin/controller/LogController.java
@@ -1,0 +1,38 @@
+package com.quostomize.quostomize_be.api.admin.controller;
+
+import com.quostomize.quostomize_be.api.admin.dto.SystemLogResponseDto;
+import com.quostomize.quostomize_be.domain.log.entity.SystemLog;
+import com.quostomize.quostomize_be.domain.log.repository.SystemLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/api/admin/logs")
+@RequiredArgsConstructor
+public class LogController {
+
+    private final SystemLogRepository systemLogRepository;
+
+    @GetMapping
+    public ResponseEntity<Page<SystemLogResponseDto>> getAllLogs(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "DESC") Sort.Direction direction
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+        Page<SystemLog> logPage = systemLogRepository.findAll(pageable);
+
+        Page<SystemLogResponseDto> responseDtoPage = logPage.map(SystemLogResponseDto::fromEntity);
+
+        return ResponseEntity.ok(responseDtoPage);
+    }
+}

--- a/src/main/java/com/quostomize/quostomize_be/api/admin/controller/LogController.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/admin/controller/LogController.java
@@ -1,6 +1,7 @@
 package com.quostomize.quostomize_be.api.admin.controller;
 
 import com.quostomize.quostomize_be.api.admin.dto.SystemLogResponseDto;
+import com.quostomize.quostomize_be.domain.admin.service.AdminService;
 import com.quostomize.quostomize_be.domain.log.entity.SystemLog;
 import com.quostomize.quostomize_be.domain.log.enums.LogType;
 import com.quostomize.quostomize_be.domain.log.repository.SystemLogRepository;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,14 +25,17 @@ import java.util.List;
 public class LogController {
 
     private final SystemLogRepository systemLogRepository;
+    private final AdminService adminService;
 
     @GetMapping("/login-logout")
     public ResponseEntity<Page<SystemLogResponseDto>> getLoginLogoutLogs(
+            Authentication auth,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "createdAt") String sortBy,
             @RequestParam(defaultValue = "DESC") Sort.Direction direction
     ) {
+        adminService.validateAdmin(auth);
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
         Page<SystemLog> logPage = systemLogRepository.findByLogTypeIn(
                 List.of(LogType.LOGIN_ATTEMPT, LogType.LOGIN_SUCCESS, LogType.LOGIN_FAILURE, LogType.LOGOUT), pageable

--- a/src/main/java/com/quostomize/quostomize_be/api/admin/controller/LogController.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/admin/controller/LogController.java
@@ -2,6 +2,7 @@ package com.quostomize.quostomize_be.api.admin.controller;
 
 import com.quostomize.quostomize_be.api.admin.dto.SystemLogResponseDto;
 import com.quostomize.quostomize_be.domain.log.entity.SystemLog;
+import com.quostomize.quostomize_be.domain.log.enums.LogType;
 import com.quostomize.quostomize_be.domain.log.repository.SystemLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/v1/api/admin/logs")
 @RequiredArgsConstructor
@@ -21,15 +24,17 @@ public class LogController {
 
     private final SystemLogRepository systemLogRepository;
 
-    @GetMapping
-    public ResponseEntity<Page<SystemLogResponseDto>> getAllLogs(
+    @GetMapping("/login-logout")
+    public ResponseEntity<Page<SystemLogResponseDto>> getLoginLogoutLogs(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "createdAt") String sortBy,
             @RequestParam(defaultValue = "DESC") Sort.Direction direction
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
-        Page<SystemLog> logPage = systemLogRepository.findAll(pageable);
+        Page<SystemLog> logPage = systemLogRepository.findByLogTypeIn(
+                List.of(LogType.LOGIN_ATTEMPT, LogType.LOGIN_SUCCESS, LogType.LOGIN_FAILURE, LogType.LOGOUT), pageable
+        );
 
         Page<SystemLogResponseDto> responseDtoPage = logPage.map(SystemLogResponseDto::fromEntity);
 

--- a/src/main/java/com/quostomize/quostomize_be/api/admin/dto/SystemLogResponseDto.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/admin/dto/SystemLogResponseDto.java
@@ -16,10 +16,9 @@ public class SystemLogResponseDto {
     private String message;
     private Long memberId;
     private LogStatus status;
-    private LocalDateTime createdAt;
     private String requestUri;
+    private LocalDateTime createdAt;
 
-    // 엔티티를 DTO로 변환하는 메서드
     public static SystemLogResponseDto fromEntity(SystemLog systemLog) {
         return new SystemLogResponseDto(
                 systemLog.getLogId(),
@@ -28,19 +27,19 @@ public class SystemLogResponseDto {
                 systemLog.getMessage(),
                 systemLog.getMemberId(),
                 systemLog.getStatus(),
-                systemLog.getCreatedAt(),
-                systemLog.getRequestUri()
+                systemLog.getRequestUri(),
+                systemLog.getCreatedAt()
         );
     }
 
-    public SystemLogResponseDto(Long logId, String traceId, LogType logType, String message, Long memberId, LogStatus status, LocalDateTime createdAt, String requestUri) {
+    public SystemLogResponseDto(Long logId, String traceId, LogType logType, String message, Long memberId, LogStatus status, String requestUri, LocalDateTime createdAt) {
         this.logId = logId;
         this.traceId = traceId;
         this.logType = logType;
         this.message = message;
         this.memberId = memberId;
         this.status = status;
-        this.createdAt = createdAt;
         this.requestUri = requestUri;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/quostomize/quostomize_be/api/admin/dto/SystemLogResponseDto.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/admin/dto/SystemLogResponseDto.java
@@ -1,0 +1,46 @@
+package com.quostomize.quostomize_be.api.admin.dto;
+
+import com.quostomize.quostomize_be.domain.log.entity.SystemLog;
+import com.quostomize.quostomize_be.domain.log.enums.LogStatus;
+import com.quostomize.quostomize_be.domain.log.enums.LogType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SystemLogResponseDto {
+
+    private Long logId;
+    private String traceId;
+    private LogType logType;
+    private String message;
+    private Long memberId;
+    private LogStatus status;
+    private LocalDateTime createdAt;
+    private String requestUri;
+
+    // 엔티티를 DTO로 변환하는 메서드
+    public static SystemLogResponseDto fromEntity(SystemLog systemLog) {
+        return new SystemLogResponseDto(
+                systemLog.getLogId(),
+                systemLog.getTraceId(),
+                systemLog.getLogType(),
+                systemLog.getMessage(),
+                systemLog.getMemberId(),
+                systemLog.getStatus(),
+                systemLog.getCreatedAt(),
+                systemLog.getRequestUri()
+        );
+    }
+
+    public SystemLogResponseDto(Long logId, String traceId, LogType logType, String message, Long memberId, LogStatus status, LocalDateTime createdAt, String requestUri) {
+        this.logId = logId;
+        this.traceId = traceId;
+        this.logType = logType;
+        this.message = message;
+        this.memberId = memberId;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.requestUri = requestUri;
+    }
+}

--- a/src/main/java/com/quostomize/quostomize_be/api/auth/controller/AuthController.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/auth/controller/AuthController.java
@@ -13,9 +13,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @Slf4j
 @Tag(name = "인증 관련 API", description = "회원 인증 관련 API 모음")
@@ -49,8 +52,16 @@ public class AuthController {
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
     public ResponseEntity<Void> logout(@CookieValue(name = "refreshToken") String refreshToken,
+                                       @CookieValue(name = "traceId", required = false) String traceId,
                                        @RequestBody @Valid LogoutRequest request, HttpServletResponse response) {
+        // traceId가 없는 경우 로그에 경고 남기고 새로운 traceId 생성
+        if (traceId == null || traceId.isEmpty()) {
+            log.warn("로그아웃 요청 시 traceId가 존재하지 않음, 새로운 traceId 생성");
+            traceId = UUID.randomUUID().toString();
+        }
+        MDC.put("traceId", traceId);
         authService.logout(request, refreshToken, response);
+        MDC.clear();
         return ResponseEntity.noContent().build();
     }
     

--- a/src/main/java/com/quostomize/quostomize_be/api/auth/dto/LoginResponse.java
+++ b/src/main/java/com/quostomize/quostomize_be/api/auth/dto/LoginResponse.java
@@ -5,6 +5,7 @@ public record LoginResponse(
         String memberRole,
         String cardStatus,
         Long memberId,
-        String memberName
+        String memberName,
+        String traceId
 ) {
 }

--- a/src/main/java/com/quostomize/quostomize_be/common/aspects/LoggingAspect.java
+++ b/src/main/java/com/quostomize/quostomize_be/common/aspects/LoggingAspect.java
@@ -1,16 +1,23 @@
 package com.quostomize.quostomize_be.common.aspects;
 
+import com.quostomize.quostomize_be.domain.log.service.LogService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.*;
 import org.springframework.stereotype.Component;
 
+import static com.quostomize.quostomize_be.domain.log.enums.LogStatus.SUCCESS;
+import static com.quostomize.quostomize_be.domain.log.enums.LogType.MAIL_SEND_SUCCESS;
 
 @Aspect
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class LoggingAspect {
+
+    private final LogService logService;
 
     /**
      * Before: 대상 메서드가 실행되기 전에 Advice를 실행
@@ -71,4 +78,9 @@ public class LoggingAspect {
         return result;
     }
 
+    @AfterReturning("execution(* com.quostomize.quostomize_be.api.mail.service.MailService.sendMail(..)) && args(email,..)")
+    public void logMailSend(String email) {
+        // 메일 발송 성공 로그 저장
+        logService.saveLog(MAIL_SEND_SUCCESS, "Mail sent to " + email, null, SUCCESS, "/v1/api/mail/send");
+    }
 }

--- a/src/main/java/com/quostomize/quostomize_be/common/config/SecurityConfig.java
+++ b/src/main/java/com/quostomize/quostomize_be/common/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.quostomize.quostomize_be.common.filter.JwtExceptionFilter;
 import com.quostomize.quostomize_be.common.jwt.JwtTokenProvider;
 import com.quostomize.quostomize_be.common.jwt.RefreshTokenRepository;
 import com.quostomize.quostomize_be.domain.customizer.customer.repository.CustomerRepository;
+import com.quostomize.quostomize_be.domain.log.service.LogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +43,7 @@ public class SecurityConfig {
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomerRepository customerRepository;
+    private final LogService logService;
 
     @Bean
     public AuthenticationManager authenticationManager(HttpSecurity httpSecurity) throws Exception {
@@ -67,7 +69,7 @@ public class SecurityConfig {
                 );
 
         // Custom Filter 추가
-        http.addFilter(new JwtAuthenticationFilter(authenticationManager, jwtTokenProvider, refreshTokenRepository, customerRepository))
+        http.addFilter(new JwtAuthenticationFilter(authenticationManager, jwtTokenProvider, refreshTokenRepository, customerRepository, logService))
                 .addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionFilter(), JwtAuthorizationFilter.class)
                 .addFilterBefore(corsFilter, JwtExceptionFilter.class);

--- a/src/main/java/com/quostomize/quostomize_be/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/quostomize/quostomize_be/common/filter/JwtAuthenticationFilter.java
@@ -11,12 +11,16 @@ import com.quostomize.quostomize_be.common.jwt.Token;
 import com.quostomize.quostomize_be.domain.auth.entity.Member;
 import com.quostomize.quostomize_be.domain.customizer.customer.entity.Customer;
 import com.quostomize.quostomize_be.domain.customizer.customer.repository.CustomerRepository;
+import com.quostomize.quostomize_be.domain.log.service.LogService;
+import com.quostomize.quostomize_be.domain.log.enums.LogStatus;
+import com.quostomize.quostomize_be.domain.log.enums.LogType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -25,6 +29,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -35,18 +40,32 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final CustomerRepository customerRepository;
-
+    private final LogService logService;
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
         log.info("[login 요청]");
         ObjectMapper mapper = new ObjectMapper();
+
+        // traceId 생성 및 MDC 설정
+        String traceId = UUID.randomUUID().toString();
+        MDC.put("traceId", traceId);
         try {
             Member member = mapper.readValue(request.getInputStream(), Member.class);
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
                     member.getMemberLoginId(), member.getMemberPassword());
+
+            // MDC에 추가 정보 설정
+            MDC.put("userId", member.getMemberLoginId());
+            MDC.put("requestUri", request.getRequestURI());
+
+            // 로그인 시도 로그 저장
+            logService.saveLog(LogType.LOGIN_ATTEMPT, "ID: " + member.getMemberLoginId() + " 사용자가 로그인 시도를 했습니다.", null, LogStatus.INFO, request.getRequestURI());
+
             return authenticationManager.authenticate(authenticationToken);
         } catch (Exception e) {
+            logService.saveLog(LogType.LOGIN_FAILURE, "로그인 실패: " + e.getMessage(), null, LogStatus.FAILURE, request.getRequestURI());
+            MDC.clear();
             throw new FilterAuthenticationException("로그인 시도에 실패했습니다.");
         }
     }
@@ -54,7 +73,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
                                             Authentication authResult) throws IOException {
-
         PrincipalDetails principal = (PrincipalDetails) authResult.getPrincipal();
         String grantedAuthority = authResult.getAuthorities().stream()
                 .findAny()
@@ -82,11 +100,18 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         cookie.setHttpOnly(true);
         response.addCookie(cookie);
 
-        //응답 데이터 작성
-        LoginResponse loginResponse = new LoginResponse("로그인 성공", grantedAuthority, findCardStatus(principal), memberId, memberName);
+        String traceId = MDC.get("traceId");
+        // MDC 설정 및 로그 기록
+        MDC.put("userId", String.valueOf(memberId));
+        MDC.put("requestUri", request.getRequestURI());
+
+        // 응답 데이터 작성
+        LoginResponse loginResponse = new LoginResponse("로그인 성공", grantedAuthority, findCardStatus(principal), memberId, memberName, traceId);
         writeJsonResponse(response, loginResponse);
 
         log.info("로그인 성공, JWT 토큰 생성");
+        logService.saveLog(LogType.LOGIN_SUCCESS, memberName + "(ID:" + memberId + ")" + " 사용자가 로그인 했습니다.", memberId, LogStatus.SUCCESS, request.getRequestURI());
+//        MDC.clear();
     }
 
     private String findCardStatus(PrincipalDetails principal) {

--- a/src/main/java/com/quostomize/quostomize_be/domain/log/entity/SystemLog.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/log/entity/SystemLog.java
@@ -1,0 +1,52 @@
+package com.quostomize.quostomize_be.domain.log.entity;
+
+import com.quostomize.quostomize_be.domain.log.enums.LogStatus;
+import com.quostomize.quostomize_be.domain.log.enums.LogType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "system_logs")
+public class SystemLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long logId;
+
+    @Column(nullable = false)
+    private String traceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private LogType logType;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private LogStatus status;
+
+    @Column(nullable = true)
+    private String requestUri;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/quostomize/quostomize_be/domain/log/enums/LogStatus.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/log/enums/LogStatus.java
@@ -1,0 +1,12 @@
+package com.quostomize.quostomize_be.domain.log.enums;
+
+public enum LogStatus {
+    TRACE,     // 상세 정보 추적용
+    DEBUG,     // 디버그용 정보
+    INFO,      // 정보성 메시지
+    WARN,      // 경고 상황
+    ERROR,     // 에러 발생
+    FATAL,     // 치명적인 오류
+    SUCCESS,   // 작업 성공
+    FAILURE    // 작업 실패
+}

--- a/src/main/java/com/quostomize/quostomize_be/domain/log/enums/LogType.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/log/enums/LogType.java
@@ -1,0 +1,34 @@
+package com.quostomize.quostomize_be.domain.log.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LogType {
+    // 로그인/로그아웃 관련
+    LOGIN_ATTEMPT("로그인 시도"),
+    LOGIN_SUCCESS("로그인 성공"),
+    LOGIN_FAILURE("로그인 실패"),
+    LOGOUT("로그아웃"),
+
+    // 메일 발송 관련
+    MAIL_SEND_SUCCESS("메일 발송 성공"),
+    MAIL_SEND_FAILURE("메일 발송 실패"),
+
+    // 결제 관련
+    PAYMENT_REQUEST("결제 요청"),
+    PAYMENT_SUCCESS("결제 성공"),
+    PAYMENT_FAILURE("결제 실패"),
+
+    // API 호출 관련
+    API_CALL("API 호출"),
+    API_SUCCESS("API 호출 성공"),
+    API_FAILURE("API 호출 실패"),
+
+    // 에러 로그 관련
+    EXCEPTION("에러 발생"),
+    VALIDATION_ERROR("유효성 검사 에러");
+
+    private final String description;
+}

--- a/src/main/java/com/quostomize/quostomize_be/domain/log/filter/MDCLoggingFilter.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/log/filter/MDCLoggingFilter.java
@@ -1,0 +1,44 @@
+package com.quostomize.quostomize_be.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class MDCLoggingFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID = "traceId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 요청 헤더에서 traceId 가져오기 (없을 경우 새로 생성)
+        String traceId = request.getHeader(TRACE_ID);
+        if (traceId == null || traceId.isEmpty()) {
+            traceId = UUID.randomUUID().toString();
+        }
+
+        // MDC에 traceId 설정
+        MDC.put(TRACE_ID, traceId);
+        // 추가 정보 설정 (예: 요청 URI, 요청자 IP 등)
+        MDC.put("requestUri", request.getRequestURI());
+        MDC.put("clientIp", request.getRemoteAddr());
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            // MDC 클리어
+            MDC.clear();
+        }
+    }
+}

--- a/src/main/java/com/quostomize/quostomize_be/domain/log/repository/SystemLogRepository.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/log/repository/SystemLogRepository.java
@@ -2,6 +2,12 @@ package com.quostomize.quostomize_be.domain.log.repository;
 
 import com.quostomize.quostomize_be.domain.log.entity.SystemLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import com.quostomize.quostomize_be.domain.log.enums.LogType;
+
+import java.util.List;
 
 public interface SystemLogRepository extends JpaRepository<SystemLog, Long> {
+    Page<SystemLog> findByLogTypeIn(List<LogType> logTypes, Pageable pageable);
 }

--- a/src/main/java/com/quostomize/quostomize_be/domain/log/repository/SystemLogRepository.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/log/repository/SystemLogRepository.java
@@ -1,0 +1,7 @@
+package com.quostomize.quostomize_be.domain.log.repository;
+
+import com.quostomize.quostomize_be.domain.log.entity.SystemLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SystemLogRepository extends JpaRepository<SystemLog, Long> {
+}

--- a/src/main/java/com/quostomize/quostomize_be/domain/log/service/LogService.java
+++ b/src/main/java/com/quostomize/quostomize_be/domain/log/service/LogService.java
@@ -1,0 +1,50 @@
+package com.quostomize.quostomize_be.domain.log.service;
+
+import com.quostomize.quostomize_be.domain.log.entity.SystemLog;
+import com.quostomize.quostomize_be.domain.log.enums.LogStatus;
+import com.quostomize.quostomize_be.domain.log.enums.LogType;
+import com.quostomize.quostomize_be.domain.log.repository.SystemLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class LogService {
+
+    private final SystemLogRepository systemLogRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveLog(LogType logType, String message, Long memberId, LogStatus status, String requestUri) {
+        // traceId 가져오기
+        String traceId = MDC.get("traceId");
+
+        // traceId가 null인 경우 생성
+        if (traceId == null || traceId.equals("")) {
+            traceId = "NO_TRACE_ID"; // 필요 시 UUID.randomUUID().toString()로 대체 가능
+            log.warn("traceId가 null이므로 기본값 사용: {}", traceId);
+        }
+
+        // 로그 엔티티 생성 및 저장
+        SystemLog logEntity = SystemLog.builder()
+                .traceId(traceId)
+                .logType(logType)
+                .message(message)
+                .memberId(memberId)
+                .status(status)
+                .requestUri(requestUri)
+                .build();
+
+        // DB에 로그 저장
+        SystemLog savedLog = systemLogRepository.save(logEntity);
+        log.info("로그 저장 확인: {}", savedLog);
+
+        // 로그를 추가로 기록 (옵션)
+        log.info("로그 저장 완료: logType: {}, memberId: {}, status: {}, traceId: {}", logType, memberId, status, traceId);
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,33 @@
+<configuration>
+    <!-- Console Appender: 일반 로그를 콘솔에 출력 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg traceId=%X{traceId}%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- File Appender: 에러 로그를 파일로 저장 -->
+    <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/error-log-%d{yyyy-MM-dd}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 하루 단위로 파일 생성 -->
+            <fileNamePattern>logs/error-log-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- 보관할 파일 최대 개수 (예: 30일간 유지) -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg traceId=%X{traceId}%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Logger 설정 -->
+    <logger name="com.quostomize.quostomize_be" level="debug" additivity="false">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE_ERROR" />    <!-- Error 로그를 별도로 관리 -->
+    </logger>
+
+    <!-- Root Logger 설정 -->
+    <root level="info">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,10 +8,24 @@
 
     <!-- File Appender: 에러 로그를 파일로 저장 -->
     <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/error-log-%d{yyyy-MM-dd}.log</file>
+        <file>logs/error/error-log-%d{yyyy-MM-dd}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- 하루 단위로 파일 생성 -->
-            <fileNamePattern>logs/error-log-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>logs/error/error-log-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- 보관할 파일 최대 개수 (예: 30일간 유지) -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg traceId=%X{traceId}%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- File Appender: INFO 로그를 파일로 저장 -->
+    <appender name="FILE_INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/info/info-log-%d{yyyy-MM-dd}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 하루 단위로 파일 생성 -->
+            <fileNamePattern>logs/info/info-log-%d{yyyy-MM-dd}.log</fileNamePattern>
             <!-- 보관할 파일 최대 개수 (예: 30일간 유지) -->
             <maxHistory>30</maxHistory>
         </rollingPolicy>
@@ -23,7 +37,8 @@
     <!-- Logger 설정 -->
     <logger name="com.quostomize.quostomize_be" level="debug" additivity="false">
         <appender-ref ref="CONSOLE" />
-        <appender-ref ref="FILE_ERROR" />    <!-- Error 로그를 별도로 관리 -->
+        <appender-ref ref="FILE_ERROR" />
+        <appender-ref ref="FILE_INFO" />
     </logger>
 
     <!-- Root Logger 설정 -->

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -18,6 +18,10 @@
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg traceId=%X{traceId}%n</pattern>
         </encoder>
+        <!-- ERROR 레벨 이상의 로그만 기록하도록 설정 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
     </appender>
 
     <!-- File Appender: INFO 로그를 파일로 저장 -->
@@ -32,6 +36,10 @@
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg traceId=%X{traceId}%n</pattern>
         </encoder>
+        <!-- INFO 레벨 이상의 로그만 기록하도록 설정 (ERROR 포함) -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
     </appender>
 
     <!-- Logger 설정 -->


### PR DESCRIPTION
```
CREATE TABLE system_logs (
    log_id BIGINT AUTO_INCREMENT PRIMARY KEY,
    trace_id VARCHAR(255) NOT NULL,
    log_type VARCHAR(50) NOT NULL, -- LOGIN, LOGOUT, MAIL_SEND_SUCCESS, MAIL_SEND_FAILURE 등
    message TEXT NOT NULL,
    member_id BIGINT,
    status VARCHAR(50) NOT NULL, -- TRACE, DEBUG, INFO, WARN, ERROR, FATAL, SUCCESS, FAILURE 등
    request_uri VARCHAR(255),
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```
위와 같은 로그 테이블 생성 후 실행

- [x] MDC 사용하여 log filter 걸기
- [x] 로그인, 로그아웃 로그 관리
- [x] `ERROR` 로그, `INFO` 로그 하루 단위 별 파일 관리